### PR TITLE
feat: フリーズノートのマッピングに対応

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -42,6 +42,8 @@ const kirizma_convert = () => {
   const mode = mode_.options[mode_.selectedIndex].id
   const target_vars = mode === 'kana' ? kana_vars : romaji_vars
   const convert_char = mode === 'kana' ? convert_kana : convert_romaji
+
+  // フリーズ識別子
   const frz_char = '＝'
 
   // 入力データ
@@ -129,14 +131,14 @@ const kirizma_convert = () => {
   target_vars.forEach(name => out_frz_data[name] = [])
 
   frames.forEach((frame, i) => {
-    // 「ー」の場合はスキップ
+    // フリーズ識別子の場合はスキップ
     if (input_kana_arr[i] === frz_char) {
       return
     }
 
     if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === frz_char
     ) {
-      // 直後が「ーー」の場合はフリーズアローへ割当
+      // 直後がフリーズ識別子の場合は自身とその次のデータをフリーズノートへ割当
       out_frz_data[convert_char(input_kana_arr[i], use_j, use_c, use_f, use_l, use_x)].push(frame, frames[i + 1])
     } else if (input_kana_arr[i]) {
       // それ以外は矢印へ割当

--- a/docs/index.js
+++ b/docs/index.js
@@ -48,7 +48,7 @@ const kirizma_convert = () => {
   let input_kana = document.getElementById('input-kana').value
   .replace(/[ａ-ｚＡ-Ｚ]/g, s => String.fromCharCode(s.charCodeAt() - 0xfee0)) // 半角化
   .replace(/[a-z]/g, s => String.fromCharCode(s.charCodeAt() - 0x20)) // 大文字化
-  .replace(/[^あ-んーA-Z]|[ぁぃぅぇぉゃゅょっゐゑ]/g, '') // 使用可能なひらがな以外削除して配列にする
+  .replace(/[^あ-んA-Z＝]|[ぁぃぅぇぉゃゅょっゐゑ]/g, '') // 使用可能なひらがな以外削除して配列にする
 
   if (mode === 'kana') {
     input_kana = input_kana.replace(/[A-Z]/g, '')
@@ -133,8 +133,7 @@ const kirizma_convert = () => {
       return
     }
 
-    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === 'ー'
-      && input_kana_arr[i + 2] && input_kana_arr[i + 2] === 'ー'
+    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === '＝'
     ) {
       // 直後が「ーー」の場合はフリーズアローへ割当
       out_frz_data[convert_char(input_kana_arr[i], use_j, use_c, use_f, use_l, use_x)].push(frame, frames[i + 1])

--- a/docs/index.js
+++ b/docs/index.js
@@ -133,8 +133,10 @@ const kirizma_convert = () => {
       return
     }
 
-    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === 'ー') {
-      // 直後が「ー」の場合はフリーズアローへ割当
+    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === 'ー'
+      && input_kana_arr[i + 2] && input_kana_arr[i + 2] === 'ー'
+    ) {
+      // 直後が「ーー」の場合はフリーズアローへ割当
       out_frz_data[convert_char(input_kana_arr[i], use_j, use_c, use_f, use_l, use_x)].push(frame, frames[i + 1])
     } else if (input_kana_arr[i]) {
       // それ以外は矢印へ割当

--- a/docs/index.js
+++ b/docs/index.js
@@ -131,8 +131,8 @@ const kirizma_convert = () => {
   target_vars.forEach(name => out_frz_data[name] = [])
 
   frames.forEach((frame, i) => {
-    // フリーズ識別子の場合はスキップ
     if (input_kana_arr[i] === frz_char) {
+      // フリーズ識別子の場合はスキップ
       return
     }
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -42,6 +42,7 @@ const kirizma_convert = () => {
   const mode = mode_.options[mode_.selectedIndex].id
   const target_vars = mode === 'kana' ? kana_vars : romaji_vars
   const convert_char = mode === 'kana' ? convert_kana : convert_romaji
+  const frz_char = '＝'
 
   // 入力データ
   const input_dos = document.getElementById('input-dos').value
@@ -129,11 +130,11 @@ const kirizma_convert = () => {
 
   frames.forEach((frame, i) => {
     // 「ー」の場合はスキップ
-    if (input_kana_arr[i] === 'ー') {
+    if (input_kana_arr[i] === frz_char) {
       return
     }
 
-    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === '＝'
+    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === frz_char
     ) {
       // 直後が「ーー」の場合はフリーズアローへ割当
       out_frz_data[convert_char(input_kana_arr[i], use_j, use_c, use_f, use_l, use_x)].push(frame, frames[i + 1])

--- a/docs/index.js
+++ b/docs/index.js
@@ -136,8 +136,7 @@ const kirizma_convert = () => {
       return
     }
 
-    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === frz_char
-    ) {
+    if (input_kana_arr[i + 1] && input_kana_arr[i + 1] === frz_char) {
       // 直後がフリーズ識別子の場合は自身とその次のデータをフリーズノートへ割当
       out_frz_data[convert_char(input_kana_arr[i], use_j, use_c, use_f, use_l, use_x)].push(frame, frames[i + 1])
     } else if (input_kana_arr[i]) {


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes

### 1. フリーズノートのマッピングに対応
- 全角の「＝」を歌詞の読み込み対象に追加し、
「る＝」のように歌詞のひらがなに「＝」を付加することでフリーズノートに変換するようにしました。
マッピング元の譜面側で、フリーズノートを配置するか通常ノートを開始/終端をセットする必要があります。
- frzLeft, frzDown などのフリーズアローの譜面を読み込み対象に追加しました。
仕組みとしては矢印・フリーズアロー関係なく結合してソートしているので、
フリーズアローで表現しても、矢印2つセットにしても同じ挙動になります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
1. キリズマのフリーズノートが後実装されましたが、マッピングは手で修正する必要がありました。
フリーズノートに対応することで以前よりフリーズノートが使いやすくなります。
※「ー」だと歌詞の加工が必要になる可能性があるため、頻度が少ない（と思われる）「＝」としました。

## :camera: スクリーンショット / Screenshot
<!-- 
    変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください
    Regarding the changes, please post a screenshot if you change the screen design.
-->
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/311c04a4-89f4-499d-a5b3-bb8b8f778a51" />

## :pencil: その他コメント / Other Comments
<!-- 
    懸念事項などがあれば記述してください
    Add any other context about the pull request here.
-->
- オプション周りの部分は変えていません。
動作に影響はないと思いますが、何かあればお願いします m(_ _)m